### PR TITLE
added installation for pathogen

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ See [#1](https://github.com/Blackrush/vim-gocode/issues/1) to see future command
 
 Add this line to your ~/.vimrc configuration file :
 
-> Bundle 'Blackrush/vim-gocode'
+    Bundle 'Blackrush/vim-gocode'
 
 And then run vim :
 
-> vim +BundleInstall
+    vim +BundleInstall
 
 If you are running under OS X, you might want to read [these instructions](https://github.com/Blackrush/vim-gocode/wiki/Installation-on-OS-X) to properly install it.
 
 ### Pathogen
 
-*todo*
+    cd ~/.vim/bundle
+    git clone git@github.com:Blackrush/vim-gocode.git


### PR DESCRIPTION
There was a _todo_ in place of the pathogen installation. I found this repo from "https://github.com/nsf/gocode/blob/9dba28b45d8e7a84961e780b44444d766e4b2225/README.md" who said said, "Alternatively take a look at the vundle/pathogen friendly repo: https://github.com/Blackrush/vim-gocode," so I figured it would be appropriate for the repo to have a pathogen install. Plus it's a really easy change (2 lines).
