### PR TITLE
Add a GoTestVerbose when go test -v is desired

### DIFF
--- a/ftplugin/go/install.vim
+++ b/ftplugin/go/install.vim
@@ -35,4 +35,14 @@ function! s:GoTest(file, relpkg)
 	endif
 endfunction
 
+command! -buffer -nargs=1 -complete=customlist,GocodeCompletePkg GoTestVerbose call s:GoTestVerbose(getcwd(), <f-args>)
+function! s:GoTestVerbose(file, relpkg)
+	let pkg=GoRelPkg(a:file, a:relpkg)
+	if pkg != -1
+		echo system('go test -v '.pkg)
+	else
+		echohl Error | echo 'You are not in a go package' | echohl None
+	endif
+endfunction
+
 let b:did_ftplugin_go_install=1


### PR DESCRIPTION
I wanted to continue to use GoTest, but wanted to see output of prints and what not so I hacked together this. I'm sure there is a more elegant solution, but I didn't want to change the existing GoTest command.
