### PR TITLE
Some fmt fixes

### DIFF
--- a/ftplugin/go/fmt.vim
+++ b/ftplugin/go/fmt.vim
@@ -16,25 +16,22 @@ if exists("b:did_ftplugin_go_fmt")
     finish
 endif
 
-if !exists("g:gocode_gofmt_tabs")
-    let g:gocode_gofmt_tabs = ' -tabs=' . (&expandtab ? 'false' : 'true')
-endif
-
-if !exists("g:gocode_gofmt_tabwidth")
-    if &expandtab
-        let g:gocode_gofmt_tabwidth = ' -tabwidth=' . &tabstop
-    else
-        let g:gocode_gofmt_tabwidth = ''
-    endif
-endif
-
 command! -buffer Fmt call s:GoFormat()
+
+" Run gofmt before saving file
 autocmd BufWritePre <buffer> :keepjumps Fmt " thanks @justinmk
 
 function! s:GoFormat()
     let view = winsaveview()
 
-    silent execute '%!gofmt' . g:gocode_gofmt_tabs . g:gocode_gofmt_tabwidth
+    " If spaces are used for indents, configure gofmt
+    if &smarttab || &expandtab
+        let tabs = ' -tabs=false -tabwidth=' . (&sw ? &sw : (&sts ? &sts : &ts))
+    else 
+        let tabs = ''
+    endif
+
+    silent execute '%!gofmt' . tabs
 
     if v:shell_error
         let errors = []


### PR DESCRIPTION
#4 was pretty interesting: command from http://stackoverflow.com/questions/10969366/vim-automatically-formatting-golang-source-code-when-saving was intended for vimrc, so every go file opened after it was autoformatted. Thus, gofmt was executed (index number of go file in session - 1) times.

Now tabwidth is selected from variables in such order shiftwidth -> softtabstop -> tabstop. It is also evaluated every time GoFormat starts, not during script initialization.
