### PR TITLE
Use tabs for formatting only based on expandtab setting

### DIFF
--- a/ftplugin/go/fmt.vim
+++ b/ftplugin/go/fmt.vim
@@ -51,7 +51,7 @@ function! s:GoFormat()
     let view = winsaveview()
 
     " If spaces are used for indents, configure gofmt
-    if &smarttab || &expandtab
+    if &expandtab
         let tabs = ' -tabs=false -tabwidth=' . (&sw ? &sw : (&sts ? &sts : &ts))
     else 
         let tabs = ''


### PR DESCRIPTION
The 'smarttab' option does not affect whether tabs or spaces are used
for indentation, and thus should not be used to determine whether the
`-tabs` flag should be used.

The 'smarttab' option only determines whether a <Tab> at the in front of
a line should align to the indentation level. From the documentation for
'smarttab':

```
What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
option.
```

If 'smarttab' is enabled but 'expandtab' is disabled, the 'Fmt' command will
not use tabs, which isn't the intended behaviour.
