### PR TITLE
Smarttabs should not automatically expand tabs.

### DIFF
--- a/ftplugin/go/fmt.vim
+++ b/ftplugin/go/fmt.vim
@@ -51,7 +51,7 @@ function! s:GoFormat()
     let view = winsaveview()
 
     " If spaces are used for indents, configure gofmt
-    if &smarttab || &expandtab
+    if &expandtab
         let tabs = ' -tabs=false -tabwidth=' . (&sw ? &sw : (&sts ? &sts : &ts))
     else 
         let tabs = ''


### PR DESCRIPTION
If expandtab is disabled but smarttab enabled gofmt should use tabs instead of spaces. tabwidth does not matter in the sourcefile in this case and can be safely ignored if expandtab is set.
