### PR TITLE
fix FromPath not return go package

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -70,7 +70,7 @@ function! go#package#FromPath(arg)
         return -1
     endif
 
-    return substitute(path, workspace . '/src/', '', '')
+    return substitute(path, workspace . 'src/', '', '')
 endfunction
 
 function! go#package#CompleteMembers(package, member)


### PR DESCRIPTION
I found bug when I call :GoCurTest , It return error message

```
can't load package: package /Users/Thanabodee/src/Go/poker/src/github.com/wingyplus/gofizzbuzz: import "/Users/Thanabodee/src/Go/poker/src/github.com/wingyplu
s/gofizzbuzz": cannot import absolute path
```

I debug and found FromPath return absolute path not a go package path. 

This is result from :CurPkg

```
/Users/Thanabodee/src/Go/poker/src/github.com/wingyplus/gofizzbuzz
```
