### PR TITLE
Ignore Helptags generated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
When using [`vim-pathogen`](https://github.com/tpope/vim-pathogen), `:Helptags` generates a file `doc/tags`

This `.gitignore` ignores that generated file (surprise surprise), and therefore keeps `pathogen` managed packages clean when stored as git submodules

Thanks
