### PR TITLE
Got FromPath() to work for GOPATHs with and without a trailling slash

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -70,7 +70,8 @@ function! go#package#FromPath(arg)
         return -1
     endif
 
-    return substitute(path, workspace . 'src/', '', '')
+    let workspace = substitute(workspace, '/$', '', '')
+    return substitute(path, workspace . '/src/', '', '')
 endfunction
 
 function! go#package#CompleteMembers(package, member)


### PR DESCRIPTION
This fixes the issue introduced by https://github.com/Blackrush/vim-gocode/commit/9dd01c9518a07de139260c450ca030c644efe28d and makes sure that the code will work regardless of whether the users specify their GOPATH with or without a trailing slash.
