### PR TITLE
Simplified commands and improved docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,20 @@ All Vim plugins from Go 1.2 are also included.
 You should *not* install this plugin with either [fsouza/go.vim](https://github.com/fsouza/go.vim) or [jnwhiteh/vim-golang](https://github.com/jnwhiteh/vim-golang)! It could take unknown effect on your setup.
 ## Commands
 
-* **:CurPkg** takes no argument and print the current file's package
 
-*Example* `:CurPkg` in the `$GOPATH/src/github.com/Blackrush/gofus/main.go` file will print `github.com/Blackrush/gofus`
-
-* **:RelPkg** takes one argument, a relative package path, and print it as a full package path
+* **:RelPkg** takes no or one argument, a relative package path, and prints it as a full package path. If no argument is given, default to current package.
 
 *Example* `:RelPkg ../pkg/child` in the `$GOPATH/src/github.com/Blackrush/gofus/main.go` file will print `github.com/Blackrush/pkg/child`
 
-* **:GoInstall** takes one argument, a relative package path, install it or print compilation errors otherwise
+* **:GoInstall** takes no or one argument, a relative package path, installs it or prints compilation errors otherwise. If no argument is given, default to current package.
 
 *Example* `:GoInstall ../pkg/child` with current working directory `$GOPATH/src/github.com/Blackrush/gofus`
 will try to install the `github.com/Blackrush/pkg/child` package
 
-* **:GoCurInstall** takes no argument and try to install the current file's package
-
-*Example* `:GoCurInstall` in the file `$GOPATH/src/github.com/Blackrush/gofus/main.go` will try to install the
-package `github.com/Blackrush/gofus`
-
-* **:GoTest** takes one argument, a relative package path, test it and print its output
+* **:GoTest** takes no or one argument, a relative package path, tests it and prints its output. If no argument is given, default to current package.
 
 *Example* `:GoTest ../pkg/child` with current working directory `$GOPATH/src/github.com/Blackrush/gofus`
 will try to test the `github.com/Blackrush/pkg/child` package
-
-* **:GoCurTest** takes no argument and try to test the current file's package
-
-*Example* `:GoCurTest` in the file `$GOPATH/src/github.com/Blackrush/gofus/main.go` will try to test the
-package `github.com/Blackrush/gofus`
 
 * **:GoImport**, **:GoImportAs** and **:GoDrop** are equivalent of original **:Import**, **:ImportAs** and **:Drop**
 but takes all a relative package path to the current working directory

--- a/doc/vim-gocode.txt
+++ b/doc/vim-gocode.txt
@@ -11,32 +11,54 @@ CONTENTS                                                 *vim-gocode-contents*
 ==============================================================================
 1. Usage                                                    *vim-gocode-usage*
 
-:Import <package>                                                    *:Import*
-Add <package> to import section of file
+                                                            *:Import*
+:Import <package>               Add <package> to import section of file.
 
-:ImportAs <alias> <package>                                        *:ImportAs*
-Add <package> to import section of file with name <alias>
+                                                            *:ImportAs*
+:ImportAs <alias> <package>     Add <package> to import section of file with 
+                                name <alias>.
 
-:Drop <package>                                                        *:Drop*
-Remove <package> from import section of file
+                                                            *:Drop*
+:Drop <package>                 Remove <package> from import section of file.
 
-:Fmt                                                                    *:Fmt*
-Format file with gofmt
+                                                            *:Fmt*
+:Fmt                            Format file with gofmt.
 
-:Godoc [<words>]                                                      *:Godoc*
-Open Godoc for <words>. If no arguments given open Godoc for word under the
-cursor.
+                                                            *:Godoc*
+:Godoc [<words>]                Open Godoc for <words>. If no arguments given
+                                open Godoc for word under the cursor.
 
-:CurPkg                                                              *:CurPkg*
-Print current file's package
-Example: :CurPkg in the "$GOPATH/src/github.com/Blackrush/gofus/main.go"
-         file will print "github.com/Blackrush/gofus"
+                                                            *:RelPkg*
+:RelPkg [<rel-path>]            Print full package path of <rel-path>. If no
+                                argument is given, default to current package.
 
-:RelPkg <rel-path>                                                *:RelPkg*
-Print full package path of <rel-path>
-Example: :GoCurInstall in the file
-         "$GOPATH/src/github.com/Blackrush/gofus/main.go" will try to install
-         the package "github.com/Blackrush/gofus"
+
+                                                            *:GoInstall*
+:GoInstall [<rel-path>]         Install the package at <rel-path> or current
+                                package if no argument is given.
+
+                                                            *:GoTest*
+:GoTest [<rel-path>]            Test the package at <rel-path> or current
+                                package if no argument is given.
+
+
+                                                            *:GoTestVerbose*
+:GoTestVerbse [<rel-path>]      Verbosely test the pacakge at <re-path> or 
+                                current package if no argument is given.
+
+
+                                                            *:GoImport*
+:GoImport <rel-path>            Same as |:Import| but take a relative package
+                                path to the current working directory.
+
+                                                            *:GoImportAs*
+:GoImportAs <rel-path>          Same as |:ImportAs| but take a relative 
+                                package path to the current working directory.
+
+
+                                                            *:GoDrop*
+:GoDrop <rel-path>              Same as |:Drop| but take a relative package 
+                                path to the current working directory.
 
 ==============================================================================
 

--- a/ftplugin/go/install.vim
+++ b/ftplugin/go/install.vim
@@ -7,15 +7,19 @@ if !exists('g:go_install_commands')
 endif
 
 if g:go_install_commands
-    command! -buffer -nargs=1 -complete=dir GoInstall call s:GoInstall(getcwd(), <f-args>)
-    command! -buffer -nargs=1 -complete=dir GoTestVerbose call s:GoTestVerbose(getcwd(), <f-args>)
-    command! -buffer GoCurInstall call s:GoInstall(@%, '.')
-    command! -buffer -nargs=1 -complete=dir GoTest call s:GoTest(getcwd(), <f-args>)
-    command! -buffer GoCurTest call s:GoTest(@%, '.')
+    command! -buffer -nargs=? -complete=dir GoInstall call s:GoInstall(getcwd(), <f-args>)
+    command! -buffer -nargs=? -complete=dir GoTest call s:GoTest(getcwd(), <f-args>)
+    command! -buffer -nargs=? -complete=dir GoTestVerbose call s:GoTestVerbose(getcwd(), <f-args>)
 endif
 
-function! s:GoInstall(file, relpkg)
-    let pkg=GoRelPkg(a:file, a:relpkg)
+function! s:GoInstall(file, ...)
+    if a:0 == 0
+        " no arguments
+        let relpkg = '.'
+    else
+        let relpkg = a:1
+    endif
+    let pkg=GoRelPkg(a:file, relpkg)
     if pkg != -1
         let output=system('go install '.pkg)
         if !v:shell_error
@@ -28,8 +32,14 @@ function! s:GoInstall(file, relpkg)
     endif
 endfunction
 
-function! s:GoTest(file, relpkg)
-    let pkg=GoRelPkg(a:file, a:relpkg)
+function! s:GoTest(file, ...)
+    if a:0 == 0
+        " no arguments
+        let relpkg = '.'
+    else
+        let relpkg = a:1
+    endif
+    let pkg=GoRelPkg(a:file, relpkg)
     if pkg != -1
         echo system('go test '.pkg)
     else
@@ -37,8 +47,14 @@ function! s:GoTest(file, relpkg)
     endif
 endfunction
 
-function! s:GoTestVerbose(file, relpkg)
-    let pkg=GoRelPkg(a:file, a:relpkg)
+function! s:GoTestVerbose(file, ...)
+    if a:0 == 0
+        " no arguments
+        let relpkg = '.'
+    else
+        let relpkg = a:1
+    endif
+    let pkg=GoRelPkg(a:file, relpkg)
     if pkg != -1
         echo system('go test -v '.pkg)
     else

--- a/ftplugin/go/pkg.vim
+++ b/ftplugin/go/pkg.vim
@@ -7,8 +7,7 @@ if !exists('g:go_package_commands')
 endif
 
 if g:go_package_commands
-    command! -buffer CurPkg call s:GoCurPkg()
-    command! -buffer -nargs=1 RelPkg call s:GoRelPkg(<f-args>)
+    command! -buffer -nargs=? RelPkg call s:GoRelPkg(<f-args>)
 endif
 
 function! GoRelPkg(file, relpkg)
@@ -28,8 +27,13 @@ function! s:GoCurPkg()
     endif
 endfunction
 
-function! s:GoRelPkg(rel)
-    let pkg=GoRelPkg(@%, a:rel)
+function! s:GoRelPkg(...)
+    if a:0 == 0 
+        let relpkg = '.'
+    else
+        let relpkg = a:1
+    endif
+    let pkg=GoRelPkg(@%, relpkg)
     if pkg != -1
         echo pkg
     else


### PR DESCRIPTION
Got rid of :CurPkg :GoCurInstall :GoCurTest commands and made :RelPkg
:GoInstall :GoTest :GoTestVerbose commands take an optional argument
which defaults to the current package.

Reformatted the Vim help doc for easier visual scanning and added
doc for missing commands.
