### PR TITLE
Wrapping the gofmt specific flags in a if statement to allow override of...

### DIFF
--- a/ftplugin/go/fmt.vim
+++ b/ftplugin/go/fmt.vim
@@ -51,10 +51,12 @@ function! s:GoFormat()
     let view = winsaveview()
 
     " If spaces are used for indents, configure gofmt
-    if &expandtab
-        let tabs = ' -tabs=false -tabwidth=' . (&sw ? &sw : (&sts ? &sts : &ts))
-    else 
-        let tabs = ''
+
+    let tabs = ''
+    if g:gofmt_command == "gofmt"
+        if &expandtab
+            let tabs = ' -tabs=false -tabwidth=' . (&sw ? &sw : (&sts ? &sts : &ts))
+        endif
     endif
 
     silent execute "%!" . g:gofmt_command . tabs


### PR DESCRIPTION
fixes  #27. The "let tabs" bit in a previous change added flags that were specific to gofmt but cause other tools to error when you override g:gofmt_command. 
