### PR TITLE
fixed system function setting problem

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -18,10 +18,10 @@ fu! s:gocodeCurrentBuffer()
     return file
 endf
 
-let s:vim_system = get(g:, 'gocomplete#system_function', function('system'))
+let s:vim_system = get(g:, 'gocomplete#system_function', 'system')
 
 fu! s:system(str, ...)
-    return (a:0 == 0 ? s:vim_system(a:str) : s:vim_system(a:str, join(a:000)))
+    return call(s:vim_system, [a:str] + a:000)
 endf
 
 fu! s:gocodeShellescape(arg)


### PR DESCRIPTION
Can't set system function name to lower letter variables. gocomplete#…
…system_function should be set as string of function name instead of function reference.

The Commits is from 
https://github.com/nsf/gocode/commit/c1a514b7a05d47c81e1ed0ead0f1d77c088bf484
