### PR TITLE
set tabstop=8 PRE

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -9,6 +9,7 @@ function! s:gofiletype_pre()
     let s:current_fileformats = &g:fileformats
     let s:current_fileencodings = &g:fileencodings
     set fileencodings=utf-8 fileformats=unix
+		set tabstop=8
     setlocal filetype=go
 endfunction
 


### PR DESCRIPTION
Makes the Code look like 90% of the Golang code in the web, sets tabstop to 8 in the filetype PRE_open function.

Greetings Marc